### PR TITLE
Fixed parens on shifts

### DIFF
--- a/gekkota.py
+++ b/gekkota.py
@@ -149,9 +149,13 @@ class Expression(Statement):
         return self.make_binary_op(other, "**")
 
     def __rshift__(self, other: "Expression") -> "BinaryExpr":
+        if isinstance(other, BinaryExpr) and other.op in ["<<", ">>"]:
+            other = Parens(other)
         return self.make_binary_op(other, ">>")
 
     def __lshift__(self, other: "Expression") -> "BinaryExpr":
+        if isinstance(other, BinaryExpr) and other.op in ["<<", ">>"]:
+            other = Parens(other)
         return self.make_binary_op(other, "<<")
 
     def eq(self, other: "Expression") -> "BinaryExpr":
@@ -537,7 +541,7 @@ class DoubleStarArg(StarArg):
 class Slash(FuncArg):
     def __init__(self):
         pass
-    
+
     def render(self, tab_size: int) -> StrGen:
         yield "/"
 
@@ -832,7 +836,6 @@ class Assignment(Statement):
 
 
 AugTarget = Union[Name, GetAttr, Indexing]
-
 
 
 class AugmentedAssignment(Statement):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gekkota"
-version = "0.1.6"
+version = "0.2.6"
 description = "Python code-generation for Python"
 authors = ["Dmitry Gritsenko <k01419q45@ya.ru>"]
 license = "MIT"


### PR DESCRIPTION
Shift operation depends on parens:
1 << (2 << 3) [65536]
is not the same as
1 << 2 << 3 [32]