### PR TITLE
Compact rendering and less parens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - lord
-      - dev
   pull_request:
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gekkota"
-version = "0.2.6"
+version = "0.3.6"
 description = "Python code-generation for Python"
 authors = ["Dmitry Gritsenko <k01419q45@ya.ru>"]
 license = "MIT"

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -10,6 +10,7 @@ c = Name("c")
 class TestClass:
     def test_block(self):
         assert Block([]).render_str(tab_size=4) == "\n    pass"
+        assert Block([]).render_str(tab_size=4, compact=True) == "\n    pass"
         assert Block([a]).render_str(tab_size=4) == "\n    a"
         assert Block([a, b]).render_str(tab_size=4) == "\n    a\n    b"
 

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -48,6 +48,8 @@ class TestClass:
         assert (a * (a + b)).render_str() == "a * (a + b)"
         assert (-(a + b)).render_str() == "-(a + b)"
         assert (a.and_(b)).not_().render_str() == "not (a and b)"
+        assert (a << (b << c)).render_str() == "a << (b << c)"
+        assert (a >> (b >> c)).render_str() == "a >> (b >> c)"
 
     def test_attr(self):
         assert a.getattr("b").render_str() == "a.b"
@@ -92,5 +94,16 @@ class TestClass:
 
         assert StarArg(a + b).render_str() == "*(a + b)"
         assert DoubleStarArg(a + b).render_str() == "**(a + b)"
+
+    def test_compact(self):
+        one = Literal(1)
+        two = Literal(2)
+        half_float = Literal(0.5)
+
+        assert (one + two).render_str(compact=True) == "1+2"
+        assert one.and_(two).render_str(compact=True) == "1and 2"
+        assert one.and_(half_float).render_str(compact=True) == "1and.5"
+        assert (a + b).render_str(compact=True) == "a+b"
+        assert a.and_(b).render_str(compact=True) == "a and b"
 
 


### PR DESCRIPTION
- Optional argument `compact: bool = False` to `Renderable.render_str`
    If true, only significant whitespace would remain in the result, and leading zeroes of floats would be cut
    (e.g. `5 if 0.6 else 0.1` would be reduced to `5if.6else.1`)
- String and bytes literals now won't use parens for any operation on them