### PR TITLE
Fixed `Utils.separated_str` yielding first string by character

### DIFF
--- a/gekkota/utils.py
+++ b/gekkota/utils.py
@@ -33,7 +33,7 @@ class Utils:
         if not len(strings):
             yield ""
             return
-        yield from strings[0]
+        yield strings[0]
         for renderable in strings[1:]:
             yield from separator
             yield renderable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gekkota"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python code-generation for Python"
 authors = ["Dmitry Gritsenko <k01419q45@ya.ru>"]
 license = "MIT"


### PR DESCRIPTION
While unnoticeable with default config, this breaks GetAttr with `compact` set to `True`